### PR TITLE
Support SWA frontend and Atlas database deployment

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-MONGO_URI=mongodb://mongo:27017
+MONGO_URI=mongodb+srv://<username>:<password>@<cluster-host>/betterkahoots?retryWrites=true&w=majority
 MONGO_DB=betterkahoots
-ADMIN_KEY=mysecret123
-CORS_ORIGINS=http://localhost:5173,http://localhost:8080
+ADMIN_KEY=change-me
+CORS_ORIGINS=https://<your-swa-app>.azurestaticapps.net,http://localhost:5173

--- a/README.md
+++ b/README.md
@@ -1,1 +1,81 @@
 # BetterKahoots
+
+## Deployment overview
+
+BetterKahoots is split between a React front end and a FastAPI backend.
+For Azure hosting:
+
+- **Frontend** – deploy the `frontend` build output to **Azure Static Web Apps (SWA)**.
+- **Backend** – run the container image from `backend` in **Azure App Service for Containers**.
+- **Database** – connect the backend to your **MongoDB Atlas** cluster via environment variables.
+
+The sections below outline the required configuration.
+
+## Backend (Azure App Service for Containers)
+
+1. Build and push the backend image to your container registry:
+
+   ```bash
+   docker build -t <registry>/betterkahoots-backend:latest ./backend
+   docker push <registry>/betterkahoots-backend:latest
+   ```
+
+2. Create an App Service for Containers instance and configure it to pull the image.
+3. Set the following App Service settings:
+   - `WEBSITES_PORT=8000` so App Service routes traffic to Uvicorn.
+   - `PORT=8000` (optional but keeps local and cloud configs consistent).
+   - `MONGO_URI` – the MongoDB Atlas connection string (for example `mongodb+srv://...`).
+   - `MONGO_DB=betterkahoots` or your chosen database name.
+   - `ADMIN_KEY` – the value used to protect admin routes.
+   - `CORS_ORIGINS` – include your SWA hostname (for example `https://<your-app>.azurestaticapps.net`).
+
+The backend already honours the `PORT` variable and exposes 8000 in the Dockerfile, so no
+further code changes are required for App Service.
+
+## Frontend (Azure Static Web Apps)
+
+1. Install dependencies and produce a production build:
+
+   ```bash
+   cd frontend
+   npm install
+   npm run build
+   ```
+
+   The build artefacts are written to `frontend/dist`.
+
+2. When configuring your SWA app, point the **App location** to `frontend`, the **Output location**
+   to `dist`, and leave the API location empty (the API is hosted separately).
+3. Expose the backend URL to the frontend by setting a static web app secret `VITE_API_BASE_URL`
+   to the HTTPS endpoint of your App Service instance (for example `https://betterkahoots-api.azurewebsites.net`).
+4. The included `frontend/staticwebapp.config.json` configures SPA fallback routing so client-side
+   routes resolve correctly.
+
+## MongoDB Atlas configuration
+
+1. Create a MongoDB Atlas cluster and database for BetterKahoots.
+2. Generate a database user with the necessary permissions and capture the SRV connection string.
+3. Update the backend `MONGO_URI` setting (environment variable or `.env` file) with the Atlas
+   connection string. The backend uses TLS by default when presented with an Atlas URI.
+
+## Local development
+
+- Copy `.env` and set it to match your Atlas cluster (or override with another MongoDB URI).
+- Start the backend container locally:
+
+  ```bash
+  docker compose up -d
+  ```
+
+  The API is available on `http://localhost:8000`.
+
+- Run the frontend using Vite's dev server:
+
+  ```bash
+  cd frontend
+  npm install
+  npm run dev -- --host
+  ```
+
+  Set `VITE_API_BASE_URL=http://localhost:8000` when running the frontend locally so it targets the
+  Docker hosted backend.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,5 +13,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY app ./app
 
 
+# Inform hosting environments which port the application expects
+EXPOSE 8000
+
+
 # Single worker to keep WebSocket state coherent
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1"]
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000} --workers 1"]

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,17 +1,15 @@
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from motor.motor_asyncio import AsyncIOMotorClient
 from functools import lru_cache
 
 
 class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+
     MONGO_URI: str = "mongodb://localhost:27017"
     MONGO_DB: str = "betterkahoots"
     ADMIN_KEY: str = "change-me"
     CORS_ORIGINS: str = "http://localhost:5173,http://localhost:8080"
-
-
-class Config:
-    env_file = ".env"
 
 
 @lru_cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,35 +1,10 @@
 version: "3.9"
 services:
-  mongo:
-    image: mongo:7
-    container_name: bk_mongo
-    restart: unless-stopped
-    ports:
-      - "27017:27017"
-    volumes:
-      - mongo_data:/data/db
-
-
   backend:
-    build: ./backend
-    container_name: bk_backend
+    image: ${BACKEND_IMAGE:-betterkahoots-backend:latest}
     restart: unless-stopped
     env_file: .env
-    depends_on:
-      - mongo
+    environment:
+      - PORT=8000
     ports:
       - "8000:8000"
-
-
-  frontend:
-    build: ./frontend
-    container_name: bk_frontend
-    restart: unless-stopped
-    depends_on:
-      - backend
-    ports:
-      - "8080:80"
-
-
-volumes:
-  mongo_data:

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,42 +1,89 @@
-
+import { apiUrl } from './config'
 
 export async function createOrGetSession(session_id: string) {
-const res = await fetch(`/api/session`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ session_id }) })
-if (!res.ok) throw new Error('Failed to create/get session')
-return res.json()
+  const res = await fetch(
+    apiUrl('/api/session'),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ session_id }),
+    },
+  )
+  if (!res.ok) throw new Error('Failed to create/get session')
+  return res.json()
 }
-
 
 export async function join(session_id: string, username: string) {
-const res = await fetch(`/api/join`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ session_id, username }) })
-if (!res.ok) throw new Error('Failed to join')
-return res.json()
+  const res = await fetch(
+    apiUrl('/api/join'),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ session_id, username }),
+    },
+  )
+  if (!res.ok) throw new Error('Failed to join')
+  return res.json()
 }
 
-
-export async function upsertQuestions(session_id: string, questions: any[], bonus_question: any, adminKey: string) {
-const res = await fetch(`/api/admin/questions`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'X-Admin-Key': adminKey }, body: JSON.stringify({ session_id, questions, bonus_question }) })
-if (!res.ok) throw new Error('Failed to save questions')
-return res.json()
+export async function upsertQuestions(
+  session_id: string,
+  questions: any[],
+  bonus_question: any,
+  adminKey: string,
+) {
+  const res = await fetch(
+    apiUrl('/api/admin/questions'),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Admin-Key': adminKey },
+      body: JSON.stringify({ session_id, questions, bonus_question }),
+    },
+  )
+  if (!res.ok) throw new Error('Failed to save questions')
+  return res.json()
 }
-
 
 export async function startGame(session_id: string, adminKey: string) {
-const res = await fetch(`/api/admin/start`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'X-Admin-Key': adminKey }, body: JSON.stringify({ session_id }) })
-if (!res.ok) throw new Error('Failed to start')
-return res.json()
+  const res = await fetch(
+    apiUrl('/api/admin/start'),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Admin-Key': adminKey },
+      body: JSON.stringify({ session_id }),
+    },
+  )
+  if (!res.ok) throw new Error('Failed to start')
+  return res.json()
 }
-
 
 export async function resetSession(session_id: string, adminKey: string) {
-const res = await fetch(`/api/admin/reset`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'X-Admin-Key': adminKey }, body: JSON.stringify({ session_id }) })
-if (!res.ok) throw new Error('Failed to reset session')
-return res.json()
+  const res = await fetch(
+    apiUrl('/api/admin/reset'),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Admin-Key': adminKey },
+      body: JSON.stringify({ session_id }),
+    },
+  )
+  if (!res.ok) throw new Error('Failed to reset session')
+  return res.json()
 }
 
-
-export async function submitAnswer(session_id: string, player_id: string, question_id: string, option_index: number) {
-const res = await fetch(`/api/answer`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ session_id, player_id, question_id, option_index }) })
-if (!res.ok) throw new Error('Failed to submit answer')
-return res.json()
+export async function submitAnswer(
+  session_id: string,
+  player_id: string,
+  question_id: string,
+  option_index: number,
+) {
+  const res = await fetch(
+    apiUrl('/api/answer'),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ session_id, player_id, question_id, option_index }),
+    },
+  )
+  if (!res.ok) throw new Error('Failed to submit answer')
+  return res.json()
 }

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,0 +1,14 @@
+const rawApiBase = import.meta.env.VITE_API_BASE_URL ?? ''
+
+const apiBaseUrl = rawApiBase.endsWith('/')
+  ? rawApiBase.slice(0, -1)
+  : rawApiBase
+
+function apiUrl(path: string) {
+  if (!path.startsWith('/')) {
+    return `${apiBaseUrl}/${path}`
+  }
+  return `${apiBaseUrl}${path}`
+}
+
+export { apiBaseUrl, apiUrl }

--- a/frontend/src/hooks/useEventFeed.ts
+++ b/frontend/src/hooks/useEventFeed.ts
@@ -1,5 +1,7 @@
 import { useEffect, useRef } from 'react'
 
+import { apiUrl } from '../config'
+
 import type { ServerEvent } from '../types'
 
 
@@ -45,10 +47,8 @@ export function useEventFeed(
           const params =
             lastSeqRef.current != null ? `?after=${lastSeqRef.current}` : ''
           const res = await fetch(
-            `/api/session/${encodeURIComponent(sessionId)}/events${params}`,
-
+            apiUrl(`/api/session/${encodeURIComponent(sessionId)}/events${params}`),
             { signal: controller.signal },
-
           )
           if (res.ok) {
             const data = await res.json()

--- a/frontend/staticwebapp.config.json
+++ b/frontend/staticwebapp.config.json
@@ -1,0 +1,6 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": ["/assets/*", "/icon.png", "/favicon.ico"]
+  }
+}


### PR DESCRIPTION
## Summary
- document the SWA frontend, App Service backend, and MongoDB Atlas deployment workflow
- allow the frontend to target a configurable API base URL and add Static Web Apps routing config
- refine backend environment handling, defaults, and compose setup for the Atlas-hosted database

## Testing
- npm ci *(fails: 403 Forbidden fetching packages from registry.npmjs.org in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcad38b380832bb6e1cee74ab3944e