### PR TITLE
Fix static web app deployment target

### DIFF
--- a/.github/workflows/azure-static-web-apps-polite-dune-07c418700.yml
+++ b/.github/workflows/azure-static-web-apps-polite-dune-07c418700.yml
@@ -40,6 +40,5 @@ jobs:
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
           action: "upload"
-          app_location: frontend
-          app_artifact_location: dist
+          app_location: frontend/dist
           skip_app_build: true

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- point the Azure Static Web Apps deploy action at the prebuilt `frontend/dist` directory when skipping the build step
- add the missing Vite client type reference file so TypeScript tooling recognizes `import.meta` globals

## Testing
- not run (npm registry returned HTTP 403 when reinstalling dependencies in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68dcd46fc230832baaaedc010768c688