### PR TITLE
Allow Azure Static Web Apps origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The sections below outline the required configuration.
    - `MONGO_DB=betterkahoots` or your chosen database name.
    - `ADMIN_KEY` – the value used to protect admin routes.
    - `CORS_ORIGINS` – include your SWA hostname (for example `https://<your-app>.azurestaticapps.net`).
+   - `CORS_ORIGIN_REGEX` (optional) – override the default regex (`https://.*.azurestaticapps.net`) if you host the frontend on a different domain pattern.
 
 The backend already honours the `PORT` variable and exposes 8000 in the Dockerfile, so no
 further code changes are required for App Service.

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from motor.motor_asyncio import AsyncIOMotorClient
 from functools import lru_cache
@@ -10,6 +12,7 @@ class Settings(BaseSettings):
     MONGO_DB: str = "betterkahoots"
     ADMIN_KEY: str = "change-me"
     CORS_ORIGINS: str = "http://localhost:5173,http://localhost:8080"
+    CORS_ORIGIN_REGEX: Optional[str] = r"https://.*\\.azurestaticapps\\.net"
 
 
 @lru_cache

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,10 +20,12 @@ from .schemas import (
 app = FastAPI(title="BetterKahoots API")
 
 origins = [o.strip() for o in settings.CORS_ORIGINS.split(",") if o.strip()]
+origin_regex = settings.CORS_ORIGIN_REGEX or None
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins or ["*"],
+    allow_origin_regex=origin_regex,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- allow Azure Static Web Apps frontends by default using a configurable CORS origin regex
- document the new CORS_ORIGIN_REGEX setting alongside the existing deployment guidance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcf373d4f4832ba347209e3e75eaad