### PR TITLE
Replace MongoDB with in-memory state and add question imagery

### DIFF
--- a/backend/app/game.py
+++ b/backend/app/game.py
@@ -10,6 +10,8 @@ from .utils import now_ts, sort_leaderboard
 
 CORRECT_BASE_POINTS = 10
 BONUS_POINTS = [5, 4, 3, 2, 1]
+LEADERBOARD_WAIT_SECONDS = 1.5
+LEADERBOARD_DISPLAY_SECONDS = 5
 
 
 class GameController:
@@ -237,7 +239,18 @@ class GameController:
             },
         )
 
-        # then scoreboard
+        # allow clients to highlight the correct option before showing the leaderboard
+        await asyncio.sleep(2)
+
+        await event_store.append(
+            session_id,
+            {
+                "type": "leaderboard_pending",
+                "message": "Waiting for other players…",
+            },
+        )
+
+        await asyncio.sleep(LEADERBOARD_WAIT_SECONDS)
 
         players_data = [p.model_dump() for p in s.players]
         leaderboard = sort_leaderboard(players_data)
@@ -248,7 +261,7 @@ class GameController:
             session_id,
             {
                 "type": "scoreboard",
-                "duration": 5,
+                "duration": LEADERBOARD_DISPLAY_SECONDS,
                 "leaderboard": leaderboard,
             },
         )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -25,6 +25,7 @@ class Question(BaseModel):
     text: str
     options: List[str]
     correct_index: AnswerIndex
+    image_url: Optional[str] = None
 
 
 class SessionState(str):

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import asyncio
+import mimetypes
+import os
+import uuid
+
+from azure.core.exceptions import ResourceExistsError
+from azure.storage.blob import BlobServiceClient, ContentSettings
+
+from .db import settings
+
+_blob_service_client: BlobServiceClient | None = None
+_container_initialised = False
+
+
+def _get_blob_service() -> BlobServiceClient:
+    global _blob_service_client
+    if _blob_service_client is None:
+        if not settings.AZURE_STORAGE_CONNECTION_STRING:
+            raise RuntimeError("Azure Blob Storage is not configured")
+        _blob_service_client = BlobServiceClient.from_connection_string(
+            settings.AZURE_STORAGE_CONNECTION_STRING
+        )
+    return _blob_service_client
+
+
+async def upload_question_image(
+    session_id: str,
+    question_id: str,
+    filename: str,
+    content: bytes,
+    content_type: str | None,
+) -> str:
+    if not content:
+        raise ValueError("Uploaded file was empty")
+
+    service = _get_blob_service()
+    container_name = settings.AZURE_STORAGE_CONTAINER
+    container_client = service.get_container_client(container_name)
+
+    global _container_initialised
+    if not _container_initialised:
+        try:
+            await asyncio.to_thread(container_client.create_container, public_access="blob")
+        except ResourceExistsError:
+            pass
+        _container_initialised = True
+
+    guessed_type = content_type or mimetypes.guess_type(filename)[0]
+    extension = os.path.splitext(filename)[1]
+    if not extension and guessed_type:
+        extension = mimetypes.guess_extension(guessed_type) or ""
+
+    blob_name = f"{session_id}/{question_id}-{uuid.uuid4().hex}{extension}".strip("/")
+    blob_client = container_client.get_blob_client(blob_name)
+
+    settings_kwargs = {}
+    if guessed_type:
+        settings_kwargs["content_settings"] = ContentSettings(content_type=guessed_type)
+
+    await asyncio.to_thread(blob_client.upload_blob, content, overwrite=True, **settings_kwargs)
+    return blob_client.url

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,6 @@
 fastapi==0.115.0
 uvicorn==0.30.6
-motor==3.6.0
-certifi==2024.8.30
+azure-storage-blob==12.19.1
 pydantic==2.9.2
 pydantic-settings==2.5.2
 python-dotenv==1.0.1

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -44,6 +44,27 @@ export async function upsertQuestions(
   return res.json()
 }
 
+export async function uploadQuestionImage(
+  session_id: string,
+  question_id: string,
+  file: File,
+  adminKey: string,
+) {
+  const form = new FormData()
+  form.append('session_id', session_id)
+  form.append('question_id', question_id)
+  form.append('file', file)
+
+  const res = await fetch(apiUrl('/api/admin/question-image'), {
+    method: 'POST',
+    headers: { 'X-Admin-Key': adminKey },
+    body: form,
+  })
+
+  if (!res.ok) throw new Error('Failed to upload image')
+  return res.json()
+}
+
 export async function verifyAdminKey(adminKey: string) {
   const res = await fetch(
     apiUrl('/api/admin/verify'),

--- a/frontend/src/components/Leaderboard.tsx
+++ b/frontend/src/components/Leaderboard.tsx
@@ -17,10 +17,16 @@ import type { Player } from '../types'
 export default function Leaderboard({
   open,
   players,
+  title = 'Leaderboard',
+  subtitle,
+  countdownSeconds,
   onClose,
 }: {
   open: boolean
   players: Player[]
+  title?: string
+  subtitle?: string
+  countdownSeconds?: number
   onClose?: () => void
 }) {
   const theme = useTheme()
@@ -34,6 +40,7 @@ export default function Leaderboard({
       maxWidth="sm"
       fullWidth
       PaperProps={{
+        className: 'glass-card',
         sx: {
           bgcolor: 'background.paper',
           borderRadius: fullScreen ? 0 : 4,
@@ -43,10 +50,22 @@ export default function Leaderboard({
         },
       }}
     >
-      <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', pr: 2 }}>
-        <Typography variant="h5" fontWeight={700}>
-          Leaderboard
-        </Typography>
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', pr: 2, gap: 2 }}>
+        <Box>
+          <Typography variant="h5" fontWeight={700}>
+            {title}
+          </Typography>
+          {subtitle && (
+            <Typography variant="subtitle2" color="text.secondary" sx={{ textTransform: 'uppercase', letterSpacing: 1, mt: 0.5 }}>
+              {subtitle}
+            </Typography>
+          )}
+        </Box>
+        {countdownSeconds !== undefined && countdownSeconds > 0 && (
+          <Typography variant="body2" color="text.secondary" fontWeight={600}>
+            {countdownSeconds}s
+          </Typography>
+        )}
         {onClose && (
           <IconButton onClick={onClose} edge="end" size="small" sx={{ color: 'text.secondary' }}>
             ×

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,3 +1,54 @@
 *, *::before, *::after { box-sizing: border-box; }
 html, body, #root { height: 100%; }
 body { margin: 0; }
+
+.glass-card {
+  backdrop-filter: blur(18px);
+  background-color: rgba(17, 17, 27, 0.68) !important;
+  animation: fadeSlideIn 0.45s ease;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.glass-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 26px 60px -32px rgba(137, 220, 235, 0.45);
+}
+
+.question-stage {
+  animation: fadeSlideIn 0.35s ease;
+}
+
+.question-visual {
+  animation: popIn 0.4s ease;
+}
+
+.fade-in {
+  animation: fadeIn 0.3s ease;
+}
+
+@keyframes fadeSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes popIn {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,5 +1,11 @@
 export type Player = { id: string; username: string; score: number; is_tied_finalist?: boolean }
-export type Question = { id: string; text: string; options: string[]; correct_index: number }
+export type Question = {
+  id: string
+  text: string
+  options: string[]
+  correct_index: number
+  image_url?: string | null
+}
 
 
 export type ServerEvent =
@@ -14,6 +20,7 @@ export type ServerEvent =
       deadline_ts: number
     }
   | { type: 'reveal'; question_id: string; correct_index: number; awards: Record<string, number> }
+  | { type: 'leaderboard_pending'; message: string }
   | { type: 'scoreboard'; duration: number; leaderboard: Player[] }
   | { type: 'tiebreak_start'; finalist_ids: string[] }
   | { type: 'game_over'; leaderboard: Player[] }


### PR DESCRIPTION
## Summary
- remove the MongoDB client fallback in favour of the existing in-memory collections and expose Azure Blob configuration for uploads
- add an admin endpoint and storage helper to upload optional question images and emit richer event timing for reveal/leaderboard phases
- update the React UI with image management, locked-in answers, waiting overlays, countdown leaderboards, and polished transitions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddfa07fac8832ba8cd5ab91e64e21d