### PR TITLE
Handle private Azure blob containers

### DIFF
--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -4,14 +4,21 @@ import asyncio
 import mimetypes
 import os
 import uuid
+from datetime import datetime, timedelta
 
-from azure.core.exceptions import ResourceExistsError
-from azure.storage.blob import BlobServiceClient, ContentSettings
+from azure.core.exceptions import HttpResponseError, ResourceExistsError
+from azure.storage.blob import (
+    BlobSasPermissions,
+    BlobServiceClient,
+    ContentSettings,
+    generate_blob_sas,
+)
 
 from .db import settings
 
 _blob_service_client: BlobServiceClient | None = None
 _container_initialised = False
+_container_is_private: bool | None = None
 
 
 def _get_blob_service() -> BlobServiceClient:
@@ -39,12 +46,31 @@ async def upload_question_image(
     container_name = settings.AZURE_STORAGE_CONTAINER
     container_client = service.get_container_client(container_name)
 
-    global _container_initialised
+    global _container_initialised, _container_is_private
     if not _container_initialised:
         try:
             await asyncio.to_thread(container_client.create_container, public_access="blob")
         except ResourceExistsError:
             pass
+        except HttpResponseError as exc:
+            error_code = getattr(exc, "error_code", None) or getattr(
+                getattr(exc, "error", None), "code", None
+            )
+            if error_code == "PublicAccessNotPermitted":
+                try:
+                    await asyncio.to_thread(container_client.create_container)
+                except ResourceExistsError:
+                    pass
+                _container_is_private = True
+            else:
+                raise
+        else:
+            _container_is_private = False
+
+        if _container_is_private is None:
+            properties = await asyncio.to_thread(container_client.get_container_properties)
+            public_access = getattr(properties, "public_access", None)
+            _container_is_private = public_access not in {"blob", "container"}
         _container_initialised = True
 
     guessed_type = content_type or mimetypes.guess_type(filename)[0]
@@ -60,4 +86,20 @@ async def upload_question_image(
         settings_kwargs["content_settings"] = ContentSettings(content_type=guessed_type)
 
     await asyncio.to_thread(blob_client.upload_blob, content, overwrite=True, **settings_kwargs)
+
+    if _container_is_private:
+        credential = service.credential
+        if credential is None:
+            raise RuntimeError("Azure Blob Storage credential is required for SAS generation")
+        sas_token = generate_blob_sas(
+            account_name=service.account_name,
+            container_name=container_name,
+            blob_name=blob_name,
+            credential=credential,
+            permission=BlobSasPermissions(read=True),
+            expiry=datetime.utcnow() + timedelta(minutes=15),
+        )
+        separator = "&" if "?" in blob_client.url else "?"
+        return f"{blob_client.url}{separator}{sas_token}"
+
     return blob_client.url

--- a/backend/app/test_storage.py
+++ b/backend/app/test_storage.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase, mock
+
+from azure.core.exceptions import HttpResponseError
+
+from . import storage
+
+
+class _FakeBlobClient:
+    def __init__(self, blob_name: str):
+        self.blob_name = blob_name
+        self.uploaded = []
+        self.url = f"https://example.com/{blob_name}"
+
+    def upload_blob(self, content: bytes, overwrite: bool = True, **kwargs):
+        self.uploaded.append((content, overwrite, kwargs))
+
+
+class _FakeContainerClient:
+    def __init__(self, *, creation_exception: Exception | None = None, public_access: str | None = "blob"):
+        self._creation_exception = creation_exception
+        self._public_access = public_access
+        self.create_calls: list[str | None] = []
+        self._latest_blob_client: _FakeBlobClient | None = None
+
+    def create_container(self, public_access: str | None = None):
+        self.create_calls.append(public_access)
+        if self._creation_exception and public_access:
+            raise self._creation_exception
+        if public_access:
+            self._public_access = public_access
+
+    def get_container_properties(self):
+        return SimpleNamespace(public_access=self._public_access)
+
+    def get_blob_client(self, blob_name: str) -> _FakeBlobClient:
+        self._latest_blob_client = _FakeBlobClient(blob_name)
+        return self._latest_blob_client
+
+
+class _FakeBlobService:
+    def __init__(self, container_client: _FakeContainerClient):
+        self._container_client = container_client
+        self.account_name = "account-name"
+        self.credential = object()
+
+    def get_container_client(self, container_name: str) -> _FakeContainerClient:
+        self.container_name = container_name
+        return self._container_client
+
+
+class UploadQuestionImageTests(IsolatedAsyncioTestCase):
+    def setUp(self) -> None:  # noqa: D401 - standard unittest hook
+        storage._blob_service_client = None
+        storage._container_initialised = False
+        storage._container_is_private = None
+
+    async def test_upload_public_container(self):
+        container = _FakeContainerClient()
+        service = _FakeBlobService(container)
+
+        with mock.patch("backend.app.storage._get_blob_service", return_value=service), mock.patch(
+            "backend.app.storage.generate_blob_sas"
+        ) as mock_generate_sas:
+            url = await storage.upload_question_image(
+                "session",
+                "question",
+                "image.png",
+                b"data",
+                "image/png",
+            )
+
+        self.assertEqual(url, container._latest_blob_client.url)
+        self.assertEqual(container.create_calls, ["blob"])
+        mock_generate_sas.assert_not_called()
+
+    async def test_upload_private_container_generates_sas(self):
+        error = HttpResponseError(message="forbidden")
+        error.error_code = "PublicAccessNotPermitted"
+        container = _FakeContainerClient(creation_exception=error, public_access=None)
+        service = _FakeBlobService(container)
+
+        with mock.patch("backend.app.storage._get_blob_service", return_value=service), mock.patch(
+            "backend.app.storage.generate_blob_sas", return_value="sig"
+        ) as mock_generate_sas:
+            url = await storage.upload_question_image(
+                "session",
+                "question",
+                "image.png",
+                b"data",
+                "image/png",
+            )
+
+        self.assertTrue(url.endswith("?sig"))
+        self.assertEqual(container.create_calls, ["blob", None])
+        kwargs = mock_generate_sas.call_args.kwargs
+        self.assertEqual(kwargs["account_name"], service.account_name)
+        self.assertEqual(kwargs["container_name"], storage.settings.AZURE_STORAGE_CONTAINER)
+        self.assertEqual(kwargs["blob_name"], container._latest_blob_client.blob_name)
+        self.assertIs(kwargs["credential"], service.credential)
+        self.assertEqual(str(kwargs["permission"]), str(storage.BlobSasPermissions(read=True)))
+        self.assertIn("expiry", kwargs)
+


### PR DESCRIPTION
## Summary
- handle container creation failures when public access is disabled by retrying without the flag and tracking privacy
- append a short-lived read SAS to blob URLs when uploading into private containers
- add unit tests covering uploads to public and private containers

## Testing
- python -m unittest backend.app.test_storage

------
https://chatgpt.com/codex/tasks/task_e_68de1fa462d0832babb83f252598c8a5