### PR TITLE
Support Azure blob configuration aliases

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,5 @@ MONGO_URI=mongodb+srv://<username>:<password>@<cluster-host>/betterkahoots?retry
 MONGO_DB=betterkahoots
 ADMIN_KEY=change-me
 CORS_ORIGINS=https://<your-swa-app>.azurestaticapps.net,http://localhost:5173
+AZURE_STORAGE_CONNECTION_STRING=<azure-blob-connection-string>
+AZURE_STORAGE_CONTAINER=question-images

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ The sections below outline the required configuration.
    - `ADMIN_KEY` – the value used to protect admin routes.
    - `CORS_ORIGINS` – include your SWA hostname (for example `https://<your-app>.azurestaticapps.net`).
    - `CORS_ORIGIN_REGEX` (optional) – override the default regex (`https://.*.azurestaticapps.net`) if you host the frontend on a different domain pattern.
+   - `AZURE_STORAGE_CONNECTION_STRING` – the Azure Blob Storage connection string used for question image uploads. You can also set `BLOB_CONNECTION_STRING` if you prefer that variable name.
+   - `AZURE_STORAGE_CONTAINER` (optional) – the blob container that will hold uploaded question images (defaults to `question-images`). The alternative `BLOB_CONTAINER_NAME` variable is also accepted.
    - `MONGO_TLS_CA_FILE` (optional) – absolute path to a CA bundle when your Mongo-compatible provider signs certificates with a custom authority (for example AWS DocumentDB). When left unset the backend automatically falls back to the CA bundle shipped with `certifi`, so Atlas and other providers that chain to public roots work without extra configuration.
    - `MONGO_TLS_ALLOW_INVALID_CERTS` (optional) – set to `true` only if your provider requires bypassing TLS certificate validation.
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,2 @@
+"""BetterKahoots backend application package."""
+

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -6,6 +6,7 @@ from enum import Enum
 from functools import lru_cache
 from typing import Any, Dict, Iterator, List, Optional
 
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -15,8 +16,20 @@ class Settings(BaseSettings):
     ADMIN_KEY: str = "change-me"
     CORS_ORIGINS: str = "http://localhost:5173,http://localhost:8080"
     CORS_ORIGIN_REGEX: Optional[str] = r"https://.*\\.azurestaticapps\\.net"
-    AZURE_STORAGE_CONNECTION_STRING: Optional[str] = None
-    AZURE_STORAGE_CONTAINER: str = "question-images"
+    AZURE_STORAGE_CONNECTION_STRING: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "AZURE_STORAGE_CONNECTION_STRING",
+            "BLOB_CONNECTION_STRING",
+        ),
+    )
+    AZURE_STORAGE_CONTAINER: str = Field(
+        default="question-images",
+        validation_alias=AliasChoices(
+            "AZURE_STORAGE_CONTAINER",
+            "BLOB_CONTAINER_NAME",
+        ),
+    )
 
 
 @lru_cache


### PR DESCRIPTION
## Summary
- allow the backend settings to accept either AZURE_STORAGE_* or BLOB_* environment variables when configuring Azure Blob Storage
- document the required Azure Blob Storage variables in the deployment README and sample .env file
- add an __init__ module so backend.app can be imported as a package during tests

## Testing
- `pytest backend/app/test_storage.py` *(fails: test suite expects a proper package import path; manual execution requires setting PYTHONPATH and Azure connection string)*

------
https://chatgpt.com/codex/tasks/task_e_68de2c7a5394832ba549650ff1be7a0e